### PR TITLE
Collapse admin categories

### DIFF
--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -59,10 +59,24 @@ class Application extends Component {
   transpileCategoryData = () => {
     //todo when category data is made available, currently leverages mock data
     const applicant = this.getApplicationDetails();
-    return Object.keys(adminCategories).map(adminCategory => ({
-      title: adminCategory,
-      value: applicant[adminCategory]
-    }));
+    return {
+      contact : Object.keys(adminCategories.contact).map(adminCategory => ({
+        title: adminCategory,
+        value: applicant[adminCategory]
+      })),
+      socialMedia : Object.keys(adminCategories.socialMedia).map(adminCategory => ({
+        title: adminCategory,
+        value: applicant[adminCategory]
+      })),
+      organizationInformation : Object.keys(adminCategories.organizationInformation).map(adminCategory => ({
+        title: adminCategory,
+        value: applicant[adminCategory]
+      })),
+      applicationInformation : Object.keys(adminCategories.applicationInformation).map(adminCategory => ({
+        title: adminCategory,
+        value: applicant[adminCategory]
+      }))
+    }
   };
 
   transpileFileData = () => {

--- a/src/Components/Application/column_categories.js
+++ b/src/Components/Application/column_categories.js
@@ -1,28 +1,36 @@
 //the format for adminCategories is properyName: displayOrder
 //(where a higher displayOrder corresponds to a higher position on the submissions page listview of categories)
 export const adminCategories = {
-    'Email Address': 1,
-    'Contact First Name': 2,
-    'Contact Last Name': 3,
-    'Street Address Line': 4,
-    'City': 5,
-    'Province, State or County': 6,
-    'Select a Country': 7,
-    'Postal Code': 8,
-    'Organization Name': 9,
-    'Phone Number': 10,
-    'Organization Website': 11,
-    'Charitable Registration Number': 12,
-    'Twitter': 13,
-    'Facebook': 14,
-    'Linkedin': 15,
-    'Other Social Media Link': 16,
-    "Have you discussed your application with SVP's Executive Director?": 17,
-    "Do your primary activities support residents in the Region of Waterloo?": 18,
-    "Organization Affiliation": 19,
-    "Total Number of clients served in 2019": 20,
-    "Total Number of volunteers in 2019": 21,
-    "Annual Budget": 22
+  contact:  {
+    'Contact First Name': 1,
+    'Contact Last Name': 2,
+    'Phone Number': 3,
+    'Email Address': 4,
+    'Street Address Line': 5,
+    'City': 6,
+    'Province, State or County': 7,
+    'Select a Country': 8,
+    'Postal Code': 9,
+    'Organization Website': 10
+  },
+  socialMedia: {
+    'Twitter': 1,
+    'Facebook': 2,
+    'Linkedin': 3,
+    'Other Social Media Link': 4
+  },
+  organizationInformation: {
+    'Charitable Registration Number': 1,
+    'Organization Name': 2,
+    "Organization Affiliation": 3,
+    "Total Number of clients served in 2019": 4,
+    "Total Number of volunteers in 2019": 5,
+    "Annual Budget": 6,
+    "Do your primary activities support residents in the Region of Waterloo?": 7
+  },
+  applicationInformation: {
+    "Have you discussed your application with SVP's Executive Director?": 1
+  }
 }
 
 export const fileCategories = {

--- a/src/Components/Categories/Categories.jsx
+++ b/src/Components/Categories/Categories.jsx
@@ -1,5 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -7,36 +12,154 @@ const Wrapper = styled.div`
 `;
 
 const CategoryWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 450px 450px;
-  grid-column-gap: 10px;
   font-size: 14px;
-  margin: 10px 0;
+  width: 100%;
   .category {
     display: grid;
-    grid-template-columns: 200px 250px;
-    margin: 10px 0;
+    grid-template-columns: 200px auto;
+    margin: 15px 0;
+    line-height: 20px;
   }
   .title {
     font-weight: 500;
   }
   .value {
     font-weight: normal;
+    text-align: right;
   }
 `;
 
+const SecondaryExpansionPanel = withStyles({
+  root: {
+    '&:before': {
+      display: 'none'
+    },
+    '&$expanded': {
+      margin: 0
+    }
+  },
+  expanded: {},
+})(ExpansionPanel);
+
+const SecondarySummaryPanel = withStyles({
+  root: {
+    minHeight: 0,
+    padding: 0,
+    margin: 0,
+    display: "inline-flex",
+    color: "#888888",
+    fontSize: 15,
+    textTransform: "uppercase",
+    '&$expanded': {
+      minHeight: 0
+    }
+  },
+  content: {
+    margin: 0,
+    '&$expanded': {
+      margin: 0
+    }
+  },
+  expandIcon: {
+    padding: 8
+  },
+  expanded: {},
+})(ExpansionPanelSummary);
+
+const useStyles = makeStyles({
+  mainDetailsPanel: {
+    display: "block"
+  },
+  secondaryDetailsPanel: {
+    padding: 0
+  },
+  mainSummaryPanel: {
+    margin: 0,
+    fontWeight: 500,
+    fontSize: 20
+  }
+});
+
 const Categories = ({ categoryData }) => {
+  const {contact, socialMedia, organizationInformation, applicationInformation} = categoryData;
+  const classes = useStyles();
+
   return (
     <Wrapper>
-      <h2>Administrative Categories</h2>
-      <CategoryWrapper>
-        {categoryData.map(({ title, value }) => (
-          <div className="category">
-            <span className="title">{title}</span>
-            <span className="value">{value}</span>
-          </div>
-        ))}
-      </CategoryWrapper>
+      <ExpansionPanel>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          classes={{ root: classes.mainSummaryPanel }}
+        >
+          Administrative Categories
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails classes={{ root: classes.mainDetailsPanel }}>
+          
+          <SecondaryExpansionPanel>
+            <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
+              Contact
+            </SecondarySummaryPanel>
+            <ExpansionPanelDetails classes={{ root: classes.secondaryDetailsPanel }}>
+              <CategoryWrapper>
+                {contact.map(({ title, value }) => (
+                  <div className="category">
+                    <span className="title">{title}</span>
+                    <span className="value">{value}</span>
+                  </div>
+                ))}
+              </CategoryWrapper>
+            </ExpansionPanelDetails>
+          </SecondaryExpansionPanel>
+          
+          <SecondaryExpansionPanel>
+            <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
+              Social Media
+            </SecondarySummaryPanel>
+            <ExpansionPanelDetails classes={{ root: classes.secondaryDetailsPanel }}>
+              <CategoryWrapper>
+                {socialMedia.map(({ title, value }) => (
+                  <div className="category">
+                    <span className="title">{title}</span>
+                    <span className="value">{value}</span>
+                  </div>
+                ))}
+              </CategoryWrapper>
+            </ExpansionPanelDetails>
+          </SecondaryExpansionPanel>
+          
+          <SecondaryExpansionPanel>
+            <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
+              Organization Information
+            </SecondarySummaryPanel>
+            <ExpansionPanelDetails classes={{ root: classes.secondaryDetailsPanel }}>
+              <CategoryWrapper>
+                {organizationInformation.map(({ title, value }) => (
+                  <div className="category">
+                    <span className="title">{title}</span>
+                    <span className="value">{value}</span>
+                  </div>
+                ))}
+              </CategoryWrapper>
+            </ExpansionPanelDetails>
+          </SecondaryExpansionPanel>
+
+          <SecondaryExpansionPanel>
+            <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
+              Application Information
+            </SecondarySummaryPanel>
+            <ExpansionPanelDetails classes={{ root: classes.secondaryDetailsPanel }}>
+              <CategoryWrapper>
+                {applicationInformation.map(({ title, value }) => (
+                  <div className="category">
+                    <span className="title">{title}</span>
+                    <span className="value">{value}</span>
+                  </div>
+                ))}
+              </CategoryWrapper>
+            </ExpansionPanelDetails>
+          </SecondaryExpansionPanel>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
     </Wrapper>
   );
 };

--- a/src/Components/Categories/Categories.jsx
+++ b/src/Components/Categories/Categories.jsx
@@ -117,7 +117,7 @@ const Categories = ({ categoryData }) => {
             </SecondarySummaryPanel>
             <ExpansionPanelDetails classes={{ root: classes.secondaryDetailsPanel }}>
               <CategoryWrapper>
-                {socialMedia.map(({ title, value }, index)) => (
+                {socialMedia.map(({ title, value }, index) => (
                   <div className="category" key={index}>
                     <span className="title">{title}</span>
                     <span className="value">{value}</span>


### PR DESCRIPTION
Changes
- Organize adminCategories into sub-categories. (Object of Object)
- Implement Material UI expansion Panel (and style them according to design)

Some Images Below:
<img width="280" alt="After2" src="https://user-images.githubusercontent.com/22325824/73601913-effbdd00-4537-11ea-8b93-8601836d86e2.PNG">
<img width="284" alt="After3" src="https://user-images.githubusercontent.com/22325824/73601914-f0947380-4537-11ea-9a88-f37aa907e4a2.PNG">
<img width="297" alt="After4" src="https://user-images.githubusercontent.com/22325824/73601915-f0947380-4537-11ea-9ed6-9d88b3fc66a9.PNG">
<img width="453" alt="After1" src="https://user-images.githubusercontent.com/22325824/73601916-f0947380-4537-11ea-9a7a-4d26dc40b47d.PNG">
