### PR TITLE
Change Minor Styles

### DIFF
--- a/src/Authentication/login.js
+++ b/src/Authentication/login.js
@@ -109,7 +109,7 @@ const Login = ({ history }) => {
   } else if (currentUser!==false){
   return (
     <StyledCard>
-      <CardHeader title="arbitrium" subheader="Sign-In" />
+      <CardHeader title="arbitrium" subheader="Sign In" />
       <CardContent>
         <CommentForm onSubmit={handleLogin}>
           <FormControl variant="outlined" className="textFields">

--- a/src/Components/Categories/Categories.jsx
+++ b/src/Components/Categories/Categories.jsx
@@ -87,7 +87,7 @@ const Categories = ({ categoryData }) => {
 
   return (
     <Wrapper>
-      <ExpansionPanel>
+      <ExpansionPanel defaultExpanded={true}>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
           classes={{ root: classes.mainSummaryPanel }}
@@ -96,7 +96,7 @@ const Categories = ({ categoryData }) => {
         </ExpansionPanelSummary>
         <ExpansionPanelDetails classes={{ root: classes.mainDetailsPanel }}>
 
-          <SecondaryExpansionPanel>
+          <SecondaryExpansionPanel defaultExpanded={true}>
             <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
               Contact
             </SecondarySummaryPanel>
@@ -125,7 +125,7 @@ const Categories = ({ categoryData }) => {
             </ExpansionPanelDetails>
           </SecondaryExpansionPanel>
 
-          <SecondaryExpansionPanel>
+          <SecondaryExpansionPanel defaultExpanded={true}>
             <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
               Social Media
             </SecondarySummaryPanel>
@@ -143,7 +143,7 @@ const Categories = ({ categoryData }) => {
             </ExpansionPanelDetails>
           </SecondaryExpansionPanel>
 
-          <SecondaryExpansionPanel>
+          <SecondaryExpansionPanel defaultExpanded={true}>
             <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
               Organization Information
             </SecondarySummaryPanel>
@@ -159,7 +159,7 @@ const Categories = ({ categoryData }) => {
             </ExpansionPanelDetails>
           </SecondaryExpansionPanel>
 
-          <SecondaryExpansionPanel>
+          <SecondaryExpansionPanel defaultExpanded={true}>
             <SecondarySummaryPanel expandIcon={<ExpandMoreIcon />}>
               Application Information
             </SecondarySummaryPanel>

--- a/src/Components/Categories/Categories.jsx
+++ b/src/Components/Categories/Categories.jsx
@@ -17,12 +17,13 @@ const CategoryWrapper = styled.div`
   width: 100%;
   .category {
     display: grid;
-    grid-template-columns: 200px auto;
+    grid-template-columns: 40% auto;
     margin: 15px 0;
     line-height: 20px;
   }
   .title {
     font-weight: 500;
+    padding-right: 24px;
   }
   .value {
     font-weight: normal;

--- a/src/Components/List/ApplicationList/ApplicationsTable.jsx
+++ b/src/Components/List/ApplicationList/ApplicationsTable.jsx
@@ -19,6 +19,7 @@ const Wrapper = styled.div`
   h1 {
     font-size: 24px;
     font-weight: normal;
+    text-align: left
   }
   .table {
     max-width: 864px;

--- a/src/Components/Login/Login.jsx
+++ b/src/Components/Login/Login.jsx
@@ -80,7 +80,7 @@ export default function Login({login, logout, isAuthenticated}) {
   }else{
     return(
       <StyledCard>
-        <CardHeader title="arbitrium" subheader="Sign-In"/>
+        <CardHeader title="arbitrium" subheader="Sign In"/>
         <CardContent>
           <CommentForm onSubmit={handleSubmit}>
             <FormControl variant="outlined" className="textFields">


### PR DESCRIPTION
3. On login screen, change “Log-In” to “Log in”
4. On All applicants screen, have “All Applicants” title align-left with the left side of the table
8. Default expand all the sections in the “Administrative categories” section
9. In the administrative categories table, change the column width of the field label rows to 40% and have 24px right padding