### PR TITLE
Add full application tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -115,12 +115,13 @@ class App extends Component {
   questionList:
   */
 
-  getWrappedComponent = (props, ApplicationComponent) => {
+  getWrappedComponent = (props, ApplicationComponent, fullApplication=false) => {
+    const data = fullApplication ? [] : this.props.applications;
     const WrappedComponent = (
       <ApplicationComponent
         //Passing the applications as a prop
         history={history}
-        applications={this.props.applications}
+        applications={data}
         //add common props here
         {...props}
       />
@@ -161,6 +162,13 @@ class App extends Component {
                           this.getWrappedComponent(props, ApplicationsTable)
                         }
                       ></PrivateRoute>
+                      <PrivateRoute
+                        exact={true}
+                        path="/applications/full"
+                        component={props =>
+                          this.getWrappedComponent(props, ApplicationsTable, true)
+                        }
+                      ></PrivateRoute>
                       <Route
                         exact={true}
                         path="/login"
@@ -170,6 +178,12 @@ class App extends Component {
                         path="/submissions/:organizationId"
                         component={props =>
                           this.getWrappedComponent(props, Application)
+                        }
+                      ></PrivateRoute>
+                      <PrivateRoute
+                        path="/submissions/full/:organizationId"
+                        component={props =>
+                          this.getWrappedComponent(props, Application, true)
                         }
                       ></PrivateRoute>
                       <PrivateRoute

--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -301,7 +301,7 @@ class Application extends Component {
   componentDidUpdate() {
     let appId = this.getApplicationDetails();
     if (appId) {
-      if (this.state.appId != appId._id) {
+      if (this.state.appId !== appId._id) {
         GET.getReviewAPI(this.props.user, appId._id).then(res => {
           this.setState({ review: res[0], appId: appId._id });
         });
@@ -313,7 +313,7 @@ class Application extends Component {
     let applications = this.props.applications;
 
     const currentAppIndex =
-      applications != null ? this.findApplicationIndex() : null;
+      applications !== null ? this.findApplicationIndex() : null;
     const previousApplication =
       applications && currentAppIndex > 0
         ? "/submissions/" + applications[currentAppIndex - 1]["_id"]
@@ -388,7 +388,7 @@ class Application extends Component {
               onClick={() => {
                 nextApplication
                   ? this.props.history.push(nextApplication)
-                  : console.log("Previous Application doesn't exist");
+                  : console.log("Next Application doesn't exist");
               }}
             >
               Next Applicant

--- a/src/Components/Categories/Categories.jsx
+++ b/src/Components/Categories/Categories.jsx
@@ -113,7 +113,7 @@ const Categories = ({ categoryData }) => {
               <CategoryWrapper>
                 {contact.map(({ title, value }, index) => (
                   <div className="category" key={index}>
-                    {title != "Organization Website" ? (
+                    {title !== "Organization Website" ? (
                       <>
                         <span className="title">{title}</span>
                         <span className="value">{value}</span>

--- a/src/Components/FlowSelector/FlowSelector.jsx
+++ b/src/Components/FlowSelector/FlowSelector.jsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
     font-family: inherit;
     letter-spacing: 0.3px;
     font-weight: 500;
-    border: 0px solid #005EB8;
+    border-width: 0px;
     border-bottom-width: 4px;
     padding: 20px 16px;
     &:disabled {

--- a/src/Components/Header/Header2.jsx
+++ b/src/Components/Header/Header2.jsx
@@ -1,21 +1,81 @@
-import React, {Component} from 'react';
+import React, {useState, useEffect} from 'react';
 import Menu from './Menu';
 import FlowSelector from "../FlowSelector/FlowSelector";
+import { connect } from "react-redux";
+import { push } from "connected-react-router";
 
-export default class Header2 extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {};
-    }
+import { makeStyles } from "@material-ui/core/styles";
 
-    render() {
-        return (
-              <div className="header2-container">
-              <FlowSelector>
-                  <button>1. Letter of Interest</button>
-                  <button disabled>2. Full Application</button>
-              </FlowSelector>
-              </div>
-        );
-    }
+const APPLICATION_STAGE = {
+  interest: "letter_of_interest",
+  full: "full_application"
+};
+
+//return current application stage from path
+function getNavId(pathname) {
+  const parts = pathname.split("/");
+  return (parts.length>=2 && parts[2] ==="full") ? APPLICATION_STAGE.full : APPLICATION_STAGE.interest;
 }
+
+const useStyles = makeStyles({
+  selected: {
+    borderColor: "#005EB8"
+  },
+  unselected: {
+    borderColor: "transparent"
+  }
+});
+
+const Header2 = ({ pathname, push }) => {
+    const [selected, setSelected] = useState(getNavId(pathname));
+    const styles = useStyles();
+    
+    useEffect(() => {
+      setSelected(getNavId(pathname));
+    }, [pathname]);
+
+    //Update selected state, and load new path (attach /full in the path)
+    const onNavClick = (id) => {
+        setSelected(id);
+
+        const parts = pathname.split("/");
+        const pathFirstPart = parts[1]; //submissions | applications
+        const pathAddedPart = (id === APPLICATION_STAGE.full)? "/full" : "";
+        // ie. If submissions/full/abc -> pathSecondPart does not include 'full' (it is 'abc')
+        let pathSecondPart = "";
+        if(parts.length >= 3 && parts[2] ==="full")
+            pathSecondPart = parts.slice(3).join("/");
+        else if(parts.length >= 2)
+            pathSecondPart = parts.slice(2).join("/")
+        const forwardedPath = "/"+pathFirstPart+pathAddedPart+"/"+pathSecondPart;
+        push(forwardedPath);
+    };
+
+    return (
+        <div className="header2-container">
+        <FlowSelector>
+            <button 
+              id={APPLICATION_STAGE.interest}
+              className={selected === APPLICATION_STAGE.interest ? styles.selected : styles.unselected}
+              onClick={()=>{onNavClick(APPLICATION_STAGE.interest)}}
+            >
+                1. Letter of Interest
+            </button>
+            <button
+              id={APPLICATION_STAGE.full}
+              className={selected === APPLICATION_STAGE.full ? styles.selected : styles.unselected}
+              onClick={()=>{onNavClick(APPLICATION_STAGE.full)}}
+            >
+                2. Full Application
+            </button>
+        </FlowSelector>
+        </div>
+    );
+}
+
+export default connect(
+  state => ({
+    pathname: state.router.location.pathname
+  }),
+  { push }
+)(Header2);

--- a/src/Components/List/ApplicationList/ApplicationsTable.jsx
+++ b/src/Components/List/ApplicationList/ApplicationsTable.jsx
@@ -8,11 +8,6 @@ import moment from "moment";
 
 const GET = require("../../../requests/get");
 
-const APPLICATION_STAGE = {
-  LETTER_OF_INTEREST: 0,
-  FULL_APPLICATION: 1
-};
-
 const Wrapper = styled.div`
   margin-top: 150px;
   padding: 0 136px;


### PR DESCRIPTION
Routes: (the one with 'full' indicate Full Applications/submissions in which a different data will be passed to the component. Right now it's an empty [])
```
/applications
/applications/full/   
/submissions/5df0de34d3d6094bcf944877
/submissions/full/5df0de34d3d6094bcf944877
```
Change Overview
-  Add the 2 new routes. The data passed to the component will depend on whether the route refers to a full application
- In Header2.jsx, we keep a state of the selected tab (Full Application or letter of interest) based on the current path. Then, style the active button. When tab is clicked, `onNavClick()` will calculate the new path and route it

**APPLICATION letter of interest**

<img width="632" alt="applicants" src="https://user-images.githubusercontent.com/22325824/76139845-52a63400-6022-11ea-8063-68d418af4ae6.PNG">

**APPLICATION full**

<img width="632" alt="fullApplicants" src="https://user-images.githubusercontent.com/22325824/76139844-52a63400-6022-11ea-89ff-558a91a14626.PNG">

**SUBMISSION letter of interest**

<img width="625" alt="submission" src="https://user-images.githubusercontent.com/22325824/76139849-5e91f600-6022-11ea-8f38-f99a2588bce7.PNG">

**SUBMISSION full**

<img width="634" alt="fullsubmission" src="https://user-images.githubusercontent.com/22325824/76139854-66519a80-6022-11ea-920e-4d6d0d69b8ae.PNG">

