### PR TITLE
Admin View for Candidate Submission

### DIFF
--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -2,7 +2,7 @@ import React, { useReducer, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import ApplicationView from "./ApplicationView";
 import FlowSelector from "../FlowSelector/FlowSelector";
-import Spinner from "react-spinner-material";
+// import Spinner from "react-spinner-material";
 
 //column categories
 import {
@@ -28,7 +28,7 @@ function Application({
 }) {
   const appId = match.params.organizationId;
   const [review, dispatchReviewUpdate] = useReducer(reviewReducer, null);
-  const [adminData, dispatchAdminData] = useState({
+  const [adminData, setAdminData] = useState({
     comments: null,
     overallRating: null,
     categoryRatings: null
@@ -38,9 +38,11 @@ function Application({
   useEffect(() => {
     if (isAdminView) {
       GET.getAdminViewStats(appId).then(res => {
-        adminData.comments = res.allComments;
-        adminData.categoryRatings = res.sectionAverages;
-        adminData.overallRating = res.averageRating;
+        setAdminData({
+          comments: res.allComments,
+          categoryRatings: res.sectionAverages,
+          overallRating: res.averageRating
+        });
       });
     }
   }, [isAdminView, appId]);
@@ -108,7 +110,7 @@ function Application({
         <button>1. Letter of Interest</button>
         <button disabled>2. Full Application</button>
       </FlowSelector>
-      <Spinner radius={120} color={"#333"} stroke={2} visible={true} />
+      {/* <Spinner radius={120} color={"#333"} stroke={2} visible={true} /> */}
       <Wrapper>
         <ApplicationView
           isAdminView={isAdminView}

--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -1,9 +1,7 @@
-import React, { useReducer, useEffect, useMemo, useRef } from "react";
+import React, { useReducer, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import ApplicationView from "./ApplicationView";
 import FlowSelector from "../FlowSelector/FlowSelector";
-import Files from "../Files/Files";
-import Rating from "../Rating/Rating";
 import Spinner from "react-spinner-material";
 
 //column categories
@@ -30,7 +28,22 @@ function Application({
 }) {
   const appId = match.params.organizationId;
   const [review, dispatchReviewUpdate] = useReducer(reviewReducer, null);
+  const [adminData, dispatchAdminData] = useState({
+    comments: null,
+    overallRating: null,
+    categoryRatings: null
+  });
   const isRated = useRef(false);
+
+  useEffect(() => {
+    if (isAdminView) {
+      GET.getAdminViewStats(appId).then(res => {
+        adminData.comments = res.allComments;
+        adminData.categoryRatings = res.sectionAverages;
+        adminData.overallRating = res.averageRating;
+      });
+    }
+  }, [isAdminView, appId]);
 
   //Returns a review from DB if exists, otherwise null
   useEffect(() => {
@@ -99,6 +112,7 @@ function Application({
       <Wrapper>
         <ApplicationView
           isAdminView={isAdminView}
+          adminData={adminData}
           appData={appData}
           previousApplication={previousApplication}
           nextApplication={nextApplication}

--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -1,12 +1,10 @@
 import React, { useReducer, useEffect, useMemo, useRef } from "react";
 import styled from "styled-components";
-import Button from "@material-ui/core/Button";
-import Categories from "../Categories/Categories";
-import DecisionCanvas from "../DecisionCanvas/DecisionCanvas";
+import ApplicationView from "./ApplicationView";
 import FlowSelector from "../FlowSelector/FlowSelector";
 import Files from "../Files/Files";
 import Rating from "../Rating/Rating";
-import Spinner from 'react-spinner-material';
+import Spinner from "react-spinner-material";
 
 //column categories
 import {
@@ -17,14 +15,19 @@ import {
 } from "./applicationDataHelpers";
 import { LOAD_REVIEW, reviewReducer } from "./reviewReducer";
 
-
 import { connect } from "react-redux";
-import Rubric from "../Rubric/Rubric";
 import { NEW_REVIEW } from "../../Constants/ActionTypes";
 const GET = require("../../requests/get");
 const UPDATE = require("../../requests/update");
 
-function Application({ applications, dispatch, history, match, user }) {
+function Application({
+  applications,
+  dispatch,
+  history,
+  match,
+  user,
+  isAdminView = true
+}) {
   const appId = match.params.organizationId;
   const [review, dispatchReviewUpdate] = useReducer(reviewReducer, null);
   const isRated = useRef(false);
@@ -58,7 +61,6 @@ function Application({ applications, dispatch, history, match, user }) {
       }
     });
   }, [appId, dispatch, review, user]);
-
 
   const [application, appIndex] = useMemo(() => {
     return getApplicationDetails(applications, appId);
@@ -95,60 +97,16 @@ function Application({ applications, dispatch, history, match, user }) {
       </FlowSelector>
       <Spinner radius={120} color={"#333"} stroke={2} visible={true} />
       <Wrapper>
-        <h1>
-          <Button
-            className="all-applicants"
-            onClick={() => history.push("/applications")}
-          >
-            &lt; All Applicants
-          </Button>
-          <br />
-          {name}
-        </h1>
-        <Rubric />
-        <hr />
-        {applications.length > 0 && application != null ? (
-          <div className="application-information">
-            <Categories categoryData={appData.categoryData} />
-            <hr />
-            <Files fileData={appData.fileData} />
-            <hr />
-            <DecisionCanvas
-              categoryData={appData.longAnswers}
-              update={dispatchReviewUpdate}
-              review={review}
-            />
-            <hr />
-            <Rating review={review} update={dispatchReviewUpdate} />
-            <hr />
-          </div>
-        ) : null}
-        <ApplicationSelector>
-          <Button
-            variant="contained"
-            color="primary"
-            disabled={!previousApplication}
-            onClick={() => {
-              previousApplication
-                ? history.push(previousApplication)
-                : console.log("Previous Application doesn't exist");
-            }}
-          >
-            Previous Applicant
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            disabled={!nextApplication}
-            onClick={() => {
-              nextApplication
-                ? history.push(nextApplication)
-                : console.log("Previous Application doesn't exist");
-            }}
-          >
-            Next Applicant
-          </Button>
-        </ApplicationSelector>
+        <ApplicationView
+          isAdminView={isAdminView}
+          appData={appData}
+          previousApplication={previousApplication}
+          nextApplication={nextApplication}
+          organizationName={name}
+          review={review}
+          dispatchReviewUpdate={dispatchReviewUpdate}
+          history={history}
+        />
       </Wrapper>
     </div>
   );
@@ -198,14 +156,5 @@ const Wrapper = styled.div`
     border: 0px solid #cccccc;
     border-bottom-width: 1px;
     margin: 20px 0;
-  }
-`;
-
-const ApplicationSelector = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 37px;
-  button {
-    border-radius: 0px;
   }
 `;

--- a/src/Components/Application/Application.jsx
+++ b/src/Components/Application/Application.jsx
@@ -26,7 +26,7 @@ function Application({
   history,
   match,
   user,
-  isAdminView = true
+  isAdminView
 }) {
   const appId = match.params.organizationId;
   const [review, dispatchReviewUpdate] = useReducer(reviewReducer, null);

--- a/src/Components/Application/ApplicationView.jsx
+++ b/src/Components/Application/ApplicationView.jsx
@@ -29,6 +29,7 @@ function ApplicationView(props) {
     review,
     dispatchReviewUpdate,
     isAdminView,
+    adminData,
     history
   } = props;
 
@@ -112,9 +113,10 @@ function ApplicationView(props) {
             update={dispatchReviewUpdate}
             review={review}
             isAdminView={true}
+            adminCategoryRatings={adminData.categoryRatings}
           />
           <hr />
-          <AdminRating />
+          <AdminRating adminData={adminData} />
           <hr />
         </div>
       ) : null}

--- a/src/Components/Application/ApplicationView.jsx
+++ b/src/Components/Application/ApplicationView.jsx
@@ -1,0 +1,128 @@
+import React from "react";
+import styled from "styled-components";
+import Button from "@material-ui/core/Button";
+import Categories from "../Categories/Categories";
+import DecisionCanvas from "../DecisionCanvas/DecisionCanvas";
+import Files from "../Files/Files";
+import Rating from "../Rating/Rating";
+import Rubric from "../Rubric/Rubric";
+import AdminRating from "../Rating/AdminRating";
+
+const ApplicationSelector = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 30px;
+  margin-top: 30px;
+  button {
+    border-radius: 0px;
+    height: 38px;
+  }
+`;
+
+function ApplicationView(props) {
+  const {
+    appData,
+    previousApplication,
+    nextApplication,
+    organizationName,
+    review,
+    dispatchReviewUpdate,
+    isAdminView,
+    history
+  } = props;
+
+  const buttonControls = title => (
+    <ApplicationSelector>
+      <Button
+        variant="contained"
+        color="primary"
+        disabled={!previousApplication}
+        onClick={() => {
+          previousApplication
+            ? history.push(previousApplication)
+            : console.log("Previous Application doesn't exist");
+        }}
+      >
+        Previous Applicant
+      </Button>
+      <h1>{title}</h1>
+      <Button
+        variant="contained"
+        color="primary"
+        disabled={!nextApplication}
+        p
+        onClick={() => {
+          nextApplication
+            ? history.push(nextApplication)
+            : console.log("Previous Application doesn't exist");
+        }}
+      >
+        Next Applicant
+      </Button>
+    </ApplicationSelector>
+  );
+
+  const userView = () => (
+    <>
+      <h1>
+        <Button
+          className="all-applicants"
+          onClick={() => history.push("/applications")}
+        >
+          &lt; All Applicants
+        </Button>
+        <br />
+        {organizationName}
+      </h1>
+      <Rubric />
+      <hr />
+      {appData != null ? (
+        <div className="application-information">
+          <Categories categoryData={appData.categoryData} />
+          <hr />
+          <Files fileData={appData.fileData} />
+          <hr />
+          <DecisionCanvas
+            categoryData={appData.longAnswers}
+            update={dispatchReviewUpdate}
+            review={review}
+          />
+          <hr />
+          <Rating review={review} update={dispatchReviewUpdate} />
+          <hr />
+        </div>
+      ) : null}
+      {buttonControls()}
+    </>
+  );
+
+  const adminView = () => (
+    <>
+      {buttonControls(organizationName)}
+      <hr />
+      {appData != null ? (
+        <div className="application-information">
+          <Categories categoryData={appData.categoryData} />
+          <hr />
+          <Files fileData={appData.fileData} />
+          <hr />
+          <DecisionCanvas
+            categoryData={appData.longAnswers}
+            update={dispatchReviewUpdate}
+            review={review}
+            isAdminView={true}
+          />
+          <hr />
+          <AdminRating />
+          <hr />
+        </div>
+      ) : null}
+      {buttonControls()}
+    </>
+  );
+
+  return isAdminView ? adminView() : userView();
+}
+
+export default ApplicationView;

--- a/src/Components/DecisionCanvas/AdminCanvasCard.jsx
+++ b/src/Components/DecisionCanvas/AdminCanvasCard.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import styled from "styled-components";
+import { makeStyles } from "@material-ui/core/styles";
+
+import Card from "@material-ui/core/Card";
+import Collapse from "@material-ui/core/Collapse";
+import Divider from "@material-ui/core/Divider";
+import CommentIcon from "@material-ui/icons/ChatOutlined";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Link from "@material-ui/core/Link";
+import SectionComments from "./SectionComments";
+import SectionRating from "./SectionRating";
+
+// Note that a rating of '0' is not possible.
+const ratingColour = [
+  "#55A94E",
+  "#55A94E",
+  "#51ACB9",
+  "#EB9546",
+  "#FCD717",
+  "#DE5252"
+];
+
+const ClickableHeader = styled(CardHeader)`
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  text-transform: uppercase;
+  font-weight: 500;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const Footer = styled.div`
+  display: flex;
+  .rating-label {
+    margin-right: auto;
+  }
+`;
+
+const useStyles = makeStyles({
+  collapse: {
+    marginBottom: 16
+  },
+  content: { marginTop: -16 },
+  expandOpen: {
+    transform: "rotate(180deg)"
+  },
+  root: index => ({
+    fontSize: 14,
+    borderRadius: 0,
+    borderTop: `4px solid ${ratingColour[index]}`,
+    boxShadow: "0 2px 3px 1px #cccccc",
+    marginBottom: 20
+  }),
+  title: {
+    color: "#000",
+    fontSize: "20px",
+    fontWeight: "500"
+  }
+});
+
+function AdminCanvasCard({
+  children,
+  expanded,
+  id,
+  onHeaderClick,
+  onLinkClick,
+  title
+}) {
+  let index = parseInt(id.substring(7), 10);
+  const classes = useStyles(index);
+  let rating = 0;
+
+  return (
+    <Card className={classes.root}>
+      <ClickableHeader
+        action={
+          <ExpandMoreIcon className={expanded ? classes.expandOpen : null} />
+        }
+        classes={{ title: classes.title }}
+        title={title}
+        id={id}
+        onClick={onHeaderClick}
+      />
+      <CardContent classes={{ root: classes.content }}>
+        <Collapse
+          classes={{ container: classes.collapse }}
+          collapsedHeight="75px"
+          in={expanded}
+          timeout="auto"
+        >
+          {children}
+        </Collapse>
+        {!expanded && (
+          <ReadMoreLink
+            color="textPrimary"
+            onClick={onLinkClick}
+            underline="always"
+          >
+            Read More
+          </ReadMoreLink>
+        )}
+        {!expanded && (
+          <>
+            <Divider />
+            <Footer>
+              <span className="rating-label">{`Average Rating: ${rating}/ 5`}</span>
+            </Footer>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default AdminCanvasCard;

--- a/src/Components/DecisionCanvas/AdminCanvasCard.jsx
+++ b/src/Components/DecisionCanvas/AdminCanvasCard.jsx
@@ -5,13 +5,10 @@ import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 import Collapse from "@material-ui/core/Collapse";
 import Divider from "@material-ui/core/Divider";
-import CommentIcon from "@material-ui/icons/ChatOutlined";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import CardContent from "@material-ui/core/CardContent";
 import CardHeader from "@material-ui/core/CardHeader";
 import Link from "@material-ui/core/Link";
-import SectionComments from "./SectionComments";
-import SectionRating from "./SectionRating";
 
 // Note that a rating of '0' is not possible.
 const ratingColour = [
@@ -72,11 +69,11 @@ function AdminCanvasCard({
   id,
   onHeaderClick,
   onLinkClick,
-  title
+  title,
+  adminCategoryRating
 }) {
   let index = parseInt(id.substring(7), 10);
   const classes = useStyles(index);
-  let rating = 0;
 
   return (
     <Card className={classes.root}>
@@ -111,7 +108,7 @@ function AdminCanvasCard({
           <>
             <Divider />
             <Footer>
-              <span className="rating-label">{`Average Rating: ${rating}/ 5`}</span>
+              <span className="rating-label">{`Average Rating: ${adminCategoryRating}`}</span>
             </Footer>
           </>
         )}

--- a/src/Components/DecisionCanvas/DecisionCanvas.jsx
+++ b/src/Components/DecisionCanvas/DecisionCanvas.jsx
@@ -3,6 +3,7 @@ import { produce } from "immer";
 import Button from "@material-ui/core/Button";
 import styled from "styled-components";
 import CanvasCard from "./CanvasCard";
+import AdminCanvasCard from "./AdminCanvasCard";
 
 const SectionWrapper = styled.div`
   text-align: left;
@@ -13,7 +14,6 @@ const Spacer = styled.div`
 `;
 
 const CardBody = styled.div`
-  margin-bottom: 16px;
   .answers {
     font-weight: normal;
     h3 {
@@ -31,6 +31,13 @@ const CardBody = styled.div`
       font-size: 14px;
       font-weight: normal;
       margin-top: 0;
+    }
+  }
+  .averageRating {
+    color: #888888;
+    h3 {
+      color: #000;
+      font-size: 14px;
     }
   }
 `;
@@ -70,7 +77,7 @@ function expandArrayReducer(expandedArr, { type, index }) {
   });
 }
 
-function DecisionCanvas({ update, review, categoryData }) {
+function DecisionCanvas({ update, review, categoryData, isAdminView = false }) {
   const [expandArray, dispatch] = useReducer(
     expandArrayReducer,
     categoryData.map(() => false)
@@ -84,22 +91,8 @@ function DecisionCanvas({ update, review, categoryData }) {
     }, {});
   }, [review]);
 
-  return (
-    <SectionWrapper>
-      <CanvasHeader>
-        <h2>Decision Canvas</h2>
-        <Button onClick={() => dispatch({ type: "COLLAPSE_ALL" })}>
-          Collapse All
-        </Button>
-        <Spacer />
-        <Button
-          color="primary"
-          onClick={() => dispatch({ type: "EXPAND_ALL" })}
-          variant="contained"
-        >
-          Expand All
-        </Button>
-      </CanvasHeader>
+  const renderUserCanvasCards = () => (
+    <>
       {categoryData
         ? categoryData.map((section, index) => (
             <CanvasCard
@@ -136,6 +129,69 @@ function DecisionCanvas({ update, review, categoryData }) {
             </CanvasCard>
           ))
         : null}
+    </>
+  );
+
+  const renderAdminCanvasCards = () => (
+    <>
+      {categoryData
+        ? categoryData.map((section, index) => (
+            <AdminCanvasCard
+              expanded={expandArray[index]}
+              key={section.id}
+              id={"canvas_" + section.id}
+              onHeaderClick={() => dispatch({ type: "TOGGLE", index })}
+              onLinkClick={() => dispatch({ type: "EXPAND", index })}
+              title={section.title}
+            >
+              <CardBody>
+                <div className="questions">
+                  <h3>Question(s):</h3>
+                  <ol>
+                    {section.answers.map((item, i) => (
+                      <li key={i}>{item.question}</li>
+                    ))}
+                  </ol>
+                </div>
+                <div className="answers">
+                  <h3>Candidate Answer</h3>
+                  <ol>
+                    {section.answers.map((item, i) => (
+                      <React.Fragment key={i}>
+                        <li key={i}>{item.response}</li>
+                        <h1> {"    "}</h1>
+                      </React.Fragment>
+                    ))}
+                  </ol>
+                </div>
+                <div className="averageRating">
+                  <h3>Average Rating</h3>
+                  <p> 4.5/5 </p>
+                </div>
+              </CardBody>
+            </AdminCanvasCard>
+          ))
+        : null}
+    </>
+  );
+
+  return (
+    <SectionWrapper>
+      <CanvasHeader>
+        <h2>Decision Canvas</h2>
+        <Button onClick={() => dispatch({ type: "COLLAPSE_ALL" })}>
+          Collapse All
+        </Button>
+        <Spacer />
+        <Button
+          color="primary"
+          onClick={() => dispatch({ type: "EXPAND_ALL" })}
+          variant="contained"
+        >
+          Expand All
+        </Button>
+      </CanvasHeader>
+      {isAdminView ? renderAdminCanvasCards() : renderUserCanvasCards()}
     </SectionWrapper>
   );
 }

--- a/src/Components/DecisionCanvas/DecisionCanvas.jsx
+++ b/src/Components/DecisionCanvas/DecisionCanvas.jsx
@@ -77,7 +77,13 @@ function expandArrayReducer(expandedArr, { type, index }) {
   });
 }
 
-function DecisionCanvas({ update, review, categoryData, isAdminView = false }) {
+function DecisionCanvas({
+  update,
+  review,
+  categoryData,
+  isAdminView = false,
+  adminCategoryRatings = null
+}) {
   const [expandArray, dispatch] = useReducer(
     expandArrayReducer,
     categoryData.map(() => false)
@@ -135,42 +141,48 @@ function DecisionCanvas({ update, review, categoryData, isAdminView = false }) {
   const renderAdminCanvasCards = () => (
     <>
       {categoryData
-        ? categoryData.map((section, index) => (
-            <AdminCanvasCard
-              expanded={expandArray[index]}
-              key={section.id}
-              id={"canvas_" + section.id}
-              onHeaderClick={() => dispatch({ type: "TOGGLE", index })}
-              onLinkClick={() => dispatch({ type: "EXPAND", index })}
-              title={section.title}
-            >
-              <CardBody>
-                <div className="questions">
-                  <h3>Question(s):</h3>
-                  <ol>
-                    {section.answers.map((item, i) => (
-                      <li key={i}>{item.question}</li>
-                    ))}
-                  </ol>
-                </div>
-                <div className="answers">
-                  <h3>Candidate Answer</h3>
-                  <ol>
-                    {section.answers.map((item, i) => (
-                      <React.Fragment key={i}>
-                        <li key={i}>{item.response}</li>
-                        <h1> {"    "}</h1>
-                      </React.Fragment>
-                    ))}
-                  </ol>
-                </div>
-                <div className="averageRating">
-                  <h3>Average Rating</h3>
-                  <p> 4.5/5 </p>
-                </div>
-              </CardBody>
-            </AdminCanvasCard>
-          ))
+        ? categoryData.map((section, index) => {
+            const adminCategoryRating = adminCategoryRatings
+              ? adminCategoryRatings[index].toString() + "/5"
+              : "";
+            return (
+              <AdminCanvasCard
+                expanded={expandArray[index]}
+                key={section.id}
+                id={"canvas_" + section.id}
+                onHeaderClick={() => dispatch({ type: "TOGGLE", index })}
+                onLinkClick={() => dispatch({ type: "EXPAND", index })}
+                title={section.title}
+                adminCategoryRating={adminCategoryRating}
+              >
+                <CardBody>
+                  <div className="questions">
+                    <h3>Question(s):</h3>
+                    <ol>
+                      {section.answers.map((item, i) => (
+                        <li key={i}>{item.question}</li>
+                      ))}
+                    </ol>
+                  </div>
+                  <div className="answers">
+                    <h3>Candidate Answer</h3>
+                    <ol>
+                      {section.answers.map((item, i) => (
+                        <React.Fragment key={i}>
+                          <li key={i}>{item.response}</li>
+                          <h1> {"    "}</h1>
+                        </React.Fragment>
+                      ))}
+                    </ol>
+                  </div>
+                  <div className="averageRating">
+                    <h3>Average Rating</h3>
+                    <p>{adminCategoryRating}</p>
+                  </div>
+                </CardBody>
+              </AdminCanvasCard>
+            );
+          })
         : null}
     </>
   );

--- a/src/Components/Rating/AdminRating.jsx
+++ b/src/Components/Rating/AdminRating.jsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useState, useMemo } from "react";
 import Paper from "@material-ui/core/Paper";
 import styled from "styled-components";
 import Card from "@material-ui/core/Card";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import Grid from "@material-ui/core/Grid";
+
 import Comment from "../Comment/Comment";
-import AddComment from "../AddComment/AddComment";
-import SectionRating from "../DecisionCanvas/SectionRating";
 import { makeStyles } from "@material-ui/core/styles";
 
 const StyledPaper = styled(Paper)`
@@ -33,21 +37,73 @@ const useStyles = makeStyles({
     borderRadius: 0,
     boxShadow: "0 2px 3px 1px #cccccc",
     marginBottom: 20
+  },
+  orderByLabel: {
+    fontSize: 15
   }
 });
 
-const AdminRating = () => {
+const compareByDate = (a, b) => {
+  if (a.lastReviewed < b.lastReviewed) return -1;
+  if (a.lastReviewed > b.lastReviewed) return 1;
+  return 0;
+};
+const compareByName = (a, b) => {
+  if (a._id < b._id) return -1;
+  if (a._id > b._id) return 1;
+  return 0;
+};
+
+const AdminRating = ({ adminData }) => {
+  const [sortBy, setSortBy] = useState(0);
   const classes = useStyles();
-  let comments = [];
+  const comments = useMemo(() => {
+    if (!adminData || !adminData.comments) return null;
+    let sorted = adminData.comments;
+    switch (sortBy) {
+      case 0:
+        sorted.sort(compareByDate);
+        break;
+      case 1:
+        sorted.sort(compareByName);
+        break;
+    }
+    return sorted;
+  }, [adminData.comments, sortBy]);
+
   return (
     <StyledPaper>
       <Card className={classes.root}>
         <h3>Average Overall Rating</h3>
-        <p className="overallRatingNumber">{0.0}</p>
-        <h3>Overall Comments</h3>
-        {comments.map((comment, i) => (
-          <Comment comment={comment} key={i} />
-        ))}
+        <p className="overallRatingNumber">{adminData.overallRating}</p>
+        <Grid container justify="space-between" alignItems={"center"}>
+          <Grid item sm={7} md={9}>
+            <h3>Overall Comments</h3>
+          </Grid>
+          <Grid item>
+            <label className={classes.orderByLabel} htmlFor="orderBySelect">
+              Sort by:
+            </label>
+          </Grid>
+          <Grid item>
+            <FormControl variant="outlined" className={classes.formControl}>
+              <Select
+                native
+                value={sortBy}
+                onChange={event => {
+                  setSortBy(event.target.value);
+                }}
+                inputProps={{ id: "orderBySelect" }}
+              >
+                <option value={0}>Posted date</option>
+                <option value={1}>Members</option>
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+
+        {comments &&
+          comments.map((comment, i) => <Comment comment={comment} key={i} />)}
       </Card>
     </StyledPaper>
   );

--- a/src/Components/Rating/AdminRating.jsx
+++ b/src/Components/Rating/AdminRating.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import Paper from "@material-ui/core/Paper";
+import styled from "styled-components";
+import Card from "@material-ui/core/Card";
+import Comment from "../Comment/Comment";
+import AddComment from "../AddComment/AddComment";
+import SectionRating from "../DecisionCanvas/SectionRating";
+import { makeStyles } from "@material-ui/core/styles";
+
+const StyledPaper = styled(Paper)`
+  font-size: 14px;
+  box-shadow: 0 2px 4px 2px #cccccc;
+  padding: 0px;
+  border-radius: 1px;
+  display: block;
+  text-align: left;
+  h3 {
+    margin: 0 0 8px;
+    color: #000;
+    font-size: 20px;
+    font-weight: 500;
+  }
+  .overallRatingNumber {
+    font-size: 18px;
+    margin-bottom: 20px;
+  }
+`;
+
+const useStyles = makeStyles({
+  root: {
+    padding: "16px",
+    fontSize: 14,
+    borderRadius: 0,
+    boxShadow: "0 2px 3px 1px #cccccc",
+    marginBottom: 20
+  }
+});
+
+const AdminRating = () => {
+  const classes = useStyles();
+  let comments = [];
+  return (
+    <StyledPaper>
+      <Card className={classes.root}>
+        <h3>Average Overall Rating</h3>
+        <p className="overallRatingNumber">{0.0}</p>
+        <h3>Overall Comments</h3>
+        {comments.map((comment, i) => (
+          <Comment comment={comment} key={i} />
+        ))}
+      </Card>
+    </StyledPaper>
+  );
+};
+
+export default AdminRating;


### PR DESCRIPTION
<!> Not gonna merge before API is available (in Shreyas/adminstatsview)

In order to see the admin view, pass **isAdminView=true** as prop to Application.jsx

<img width="389" alt="adminCateg" src="https://user-images.githubusercontent.com/22325824/79295472-c3086680-7ea6-11ea-9a38-4c89e8e20813.PNG">

Changes made:
- Split the UI portion of Application.jsx into a seperate component called ApplicationView.
- ApplicationView will contain both the admin and user version of Candidate Submission.
- Create new version of Canvas Card (for admin) - some differences include rating info on the footer, and not having input fields.
- In DecisionCanvas, there is render Admin and render User version.
- Create an AdminRating component (admin version of Rating in Decision canvas).