### PR TITLE
Sign user out if token is expired on initial load

### DIFF
--- a/src/Authentication/Auth.js
+++ b/src/Authentication/Auth.js
@@ -34,7 +34,7 @@ function AuthProvider({ initialAppLoad, children }) {
         return;
       }
 
-      if (user && isTokenExpired(user)) {
+      if (isTokenExpired(user)) {
         firebaseApp.auth().signOut();
         setAuthState({ state: AUTH_STATES.NOT_AUTHENTICATED, user: null });
         return;

--- a/src/Authentication/Auth.js
+++ b/src/Authentication/Auth.js
@@ -8,11 +8,11 @@ import * as GET from "../requests/get";
 export const AuthContext = React.createContext();
 
 const isTokenExpired = (user) => {
-  const MILLISECONDS_PER_HOUR = 3600 * 1000;
+  const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
   const NOW = new Date().getTime();
-  // tokens expire every hour and Firebase automatically refreshes them,
-  // so we check "expiry" by seeing if lastLoginAt is more than an hour ago
-  return Number(user.toJSON().lastLoginAt) < NOW - MILLISECONDS_PER_HOUR;
+  // Firebase tokens don't expire, they automatically refresh every hour
+  // we impose our own "expiration" time of 24 hours
+  return Number(user.toJSON().lastLoginAt) < NOW - MILLISECONDS_PER_DAY;
 };
 
 const AUTH_STATES = {


### PR DESCRIPTION
Since Firebase auth tokens automatically refresh every hour using the user's refresh token, we impose our own token "expiry" by checking if login time was more than 24 hours ago.

**Notes**:
The token check is only performed on the initial load. If a user signs in, uses the app, closes the tab without signing out, and revisits the site again >= 24 hours after the initial sign-in, they will be prompted to sign in again. Alternatively, if the user refreshes the page >= 24 hours after initial sign-in, they will also be prompted to sign in again. In any other case, the user is able to stay signed in indefinitely.