### PR TITLE
Export all candidates table data feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,11 +17978,6 @@
         "use-memo-one": "^1.1.1"
       }
     },
-    "react-csv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.0.3.tgz",
-      "integrity": "sha512-exyAdFLAxtuM4wNwLYrlKyPYLiJ7e0mv9tqPAd3kq+k1CiJFtznevR3yP0icv5q/y200w+lzNgi7TQn1Wrhu0w=="
-    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,6 +17978,11 @@
         "use-memo-one": "^1.1.1"
       }
     },
+    "react-csv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.0.3.tgz",
+      "integrity": "sha512-exyAdFLAxtuM4wNwLYrlKyPYLiJ7e0mv9tqPAd3kq+k1CiJFtznevR3yP0icv5q/y200w+lzNgi7TQn1Wrhu0w=="
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-beautiful-dnd": "^12.2.0",
+    "react-csv": "^2.0.3",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
     "react-router": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-beautiful-dnd": "^12.2.0",
-    "react-csv": "^2.0.3",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
     "react-router": "^5.1.2",

--- a/src/Components/Admin/UserManagementTable.jsx
+++ b/src/Components/Admin/UserManagementTable.jsx
@@ -37,6 +37,7 @@ const columns = [
   {
     title: "Program Access",
     field: "programs",
+    export: false,
     render: (rowData) => {
       if (rowData.programAccess.length === 0) {
         return "None";
@@ -66,7 +67,8 @@ const columns = [
     title: "",
     field: "userLink",
     sorting: false,
-    searchable: false
+    searchable: false,
+    export: false
   }
 ];
 
@@ -84,7 +86,9 @@ function UserManagementTable(props) {
           pageSize: Math.min(10, props.data.length),
           rowStyle: rowStyle,
           search: true,
-          showTitle: false
+          showTitle: false,
+          exportButton: true,
+          exportAllData: true
         }}
       />
     </div>

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -3,7 +3,6 @@ import AllCandidatesTable from "./AllCandidatesTable";
 import styled from "styled-components";
 import Button from "@material-ui/core/Button";
 import Spinner from "react-spinner-material";
-import {CSVLink} from 'react-csv';
 
 const GET = require("../../requests/get");
 
@@ -183,19 +182,6 @@ export default class AllCandidates extends Component {
                   View Committee Review
                 </Button>
               </div>
-              {/*<div className="button-container">
-                <CSVLink data={this.state.applications}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    target="_blank"
-                    value="ExportData"
-                    style={{width: '250px', maxWidth: '250px', marginLeft: '10px'}}
-                  >
-                    Export Table Data
-                  </Button>
-                </CSVLink>
-              </div>*/}
             </Header>
             <AllCandidatesTable
               data={convertToTableData(this.state.applications)}

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -3,6 +3,7 @@ import AllCandidatesTable from "./AllCandidatesTable";
 import styled from "styled-components";
 import Button from "@material-ui/core/Button";
 import Spinner from "react-spinner-material";
+import {CSVLink} from 'react-csv';
 
 const GET = require("../../requests/get");
 
@@ -181,6 +182,19 @@ export default class AllCandidates extends Component {
                 >
                   View Committee Review
                 </Button>
+              </div>
+              <div className="button-container">
+                <CSVLink data={this.state.applications}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    target="_blank"
+                    value="ExportData"
+                    style={{width: '250px', maxWidth: '250px', marginLeft: '10px'}}
+                  >
+                    Export Table Data
+                  </Button>
+                </CSVLink>
               </div>
             </Header>
             <AllCandidatesTable

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -3,7 +3,7 @@ import AllCandidatesTable from "./AllCandidatesTable";
 import styled from "styled-components";
 import Button from "@material-ui/core/Button";
 import Spinner from "react-spinner-material";
-import { CSVLink, CSVDownload } from 'react-csv';
+import { CSVLink } from 'react-csv';
 import moment from "moment";
 
 const GET = require("../../requests/get");
@@ -219,10 +219,8 @@ export default class AllCandidates extends Component {
   };
 
   exportData = () => {
-    console.log(this.refs)
     let exportApps = this.refs.csvApplications;
     let exportComments = this.refs.csvComments;
-    console.log(this.refs.csvComments.props)
     exportApps.link.click();
     exportComments.link.click();
   }
@@ -253,7 +251,7 @@ export default class AllCandidates extends Component {
                 </Button>
               </div>
               <div className="button-container">
-                <CSVLink ref="csvApplications" filename={'Ratings and Rankings - ' + moment().format("DD-MM-YYYY hh-mm-ss") + '.csv'} data={ this.state.applications } style={{display:'none'}}/>
+                <CSVLink ref="csvApplications" filename={'Ratings and Rankings - ' + moment().format("DD-MM-YYYY hh-mm-ss") + '.csv'} data={ this.state.applications.map(({ _id, ...item }) => item) } style={{display:'none'}}/>
                 <CSVLink ref="csvComments" filename={'Comments - ' + moment().format("DD-MM-YYYY hh-mm-ss") + '.csv'} data={ comments } style={{display:'none'}}/>
                 <Button
                   variant="contained"

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -183,7 +183,7 @@ export default class AllCandidates extends Component {
                   View Committee Review
                 </Button>
               </div>
-              <div className="button-container">
+              {/*<div className="button-container">
                 <CSVLink data={this.state.applications}>
                   <Button
                     variant="contained"
@@ -195,7 +195,7 @@ export default class AllCandidates extends Component {
                     Export Table Data
                   </Button>
                 </CSVLink>
-              </div>
+              </div>*/}
             </Header>
             <AllCandidatesTable
               data={convertToTableData(this.state.applications)}

--- a/src/Components/AllCandidates/AllCandidatesTable.jsx
+++ b/src/Components/AllCandidates/AllCandidatesTable.jsx
@@ -35,7 +35,11 @@ function AllCandidatesTable(props) {
           pageSize: 10,
           rowStyle: rowStyle,
           search: true,
-          showTitle: false
+          showTitle: false,
+          exportButton: true,
+          exportCsv: (columns, data) => {
+            alert('You should develop a code to export ' + data.length + ' rows');
+          }
         }}
       />
     </div>

--- a/src/Components/AllCandidates/AllCandidatesTable.jsx
+++ b/src/Components/AllCandidates/AllCandidatesTable.jsx
@@ -20,7 +20,7 @@ function AllCandidatesTable(props) {
     { title: "Candidate Name", field: "candidateName" },
     { title: "Average Rating (/5)", field: "avgRating" },
     { title: `# of Reviews (/${props.totalReviews})`, field: "numReviews" },
-    { title: "", field: "candidateLink", sorting: false, searchable: false }
+    { title: "", field: "candidateLink", sorting: false, searchable: false, export: false }
   ];
   return (
     <div>
@@ -37,9 +37,7 @@ function AllCandidatesTable(props) {
           search: true,
           showTitle: false,
           exportButton: true,
-          exportCsv: (columns, data) => {
-            alert('You should develop a code to export ' + data.length + ' rows');
-          }
+          exportAllData: true
         }}
       />
     </div>

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -50,7 +50,7 @@ const Wrapper = styled.div`
     max-width: 854px;
     width: 90vw;
     margin: 0;
-    padding-bottom: 10px;
+    padding-bottom: 20px;
     vertical-align: center;
   }
   .table {
@@ -75,12 +75,6 @@ const Wrapper = styled.div`
   }
   table.MuiTable-root {
     border: 1px solid #cccccc;
-  }
-  button {
-    max-width: 200px;
-    padding: 5px 5px;
-    text-transform: uppercase;
-    font-size: 15px;
   }
 `;
 
@@ -115,8 +109,7 @@ class CommitteeReview extends Component {
       committee: [],
       appCount: -1,
       sortDescending: true,
-      committeeSize: -1,
-      comments: []
+      committeeSize: -1
     };
   }
 
@@ -128,9 +121,7 @@ class CommitteeReview extends Component {
       // TODO: Filter the users based on their committee, schema might change
       // users = users.filter(checkCommittee)
 
-      this.setState({
-        committeeSize: users.length
-      });
+      this.setState({ committeeSize: users.length });
       for (let i = 0; i < users.length; i++) {
         GET.getReviewCountAPI(users[i].userId).then((count) => {
           let committee = [...this.state.committee];

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -7,8 +7,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleLeft } from "@fortawesome/free-solid-svg-icons";
 import { connect } from "react-redux";
 import Spinner from "react-spinner-material";
-import Button from "@material-ui/core/Button";
-import { CSVLink } from 'react-csv';
 
 const GET = require("../../requests/get");
 
@@ -131,8 +129,7 @@ class CommitteeReview extends Component {
       // users = users.filter(checkCommittee)
 
       this.setState({
-        committeeSize: users.length,
-        users: users
+        committeeSize: users.length
       });
       for (let i = 0; i < users.length; i++) {
         GET.getReviewCountAPI(users[i].userId).then((count) => {
@@ -142,73 +139,11 @@ class CommitteeReview extends Component {
         });
       }
     });
-    GET.getAllReviewsAPI().then(reviews => {
-      this.setState({ reviews: reviews });
-    })
-    GET.getAllApplicationsAPI().then(applications => {
-      this.setState({ applications: applications });
-    })
   }
 
   goBack() {
     this.props.history.push("/admin/allcandidates");
   }
-
-  // Get comments from users on each application
-  getComments = () => {
-    let commentsTotal = []
-    this.state.applications.sort().forEach((application, i) => {
-      let comments = []
-      this.state.reviews.forEach((review) => {
-        if (
-          review.applicationId === application._id &&
-          review.userId !== "vBUgTex5MeNd57fdB8u4wv7kXZ52" &&
-          review.userId !== "hM9QRmlybTdaQkLX25FupXqjiuF2"
-        ) {
-          //Go through questions and tally the comments
-          let temp = []
-          review.comments.forEach(comment =>{
-            temp.push(comment)
-          });
-          review.questionList.forEach(question =>{
-            question.notes.forEach(note => {
-              temp.push(note)
-            });
-          });
-          let email = ""
-          this.state.users.forEach(user => {
-            if (user.userId === review.userId){
-              email = user.email
-            }
-          });
-
-          let comment = {
-            comments: temp,
-            userId: email
-          }
-          if (comment.comments.length !== 0){
-            comments.push(comment)
-          }
-
-        }
-      })
-      let newComment = {
-        Name: application["Organization Name"] + ' (Total Commenters: ' + comments.length + ')',
-        Comments: ""
-      }
-      commentsTotal.push(newComment)
-      comments.forEach(comment => {
-        comment.comments.forEach(c => {
-          let newComment = {
-            Name: "",
-            Comments: c.value + ' (' + comment.userId + ')'
-          }
-          commentsTotal.push(newComment)
-        });
-      });
-    });
-    this.setState({ comments: commentsTotal });
-  };
 
   render() {
     return (
@@ -230,20 +165,6 @@ class CommitteeReview extends Component {
                   Back to Candidate Submissions
                 </span>
               </p>
-              <div className="button-container">
-                <CSVLink data={this.state.comments}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    target="_blank"
-                    value="ExportData"
-                    style={{width: '250px', maxWidth: '250px'}}
-                    onClick={() => { this.getComments() }}
-                  >
-                    Export Comments
-                  </Button>
-                </CSVLink>
-              </div>
             </Header>
             <h1 align="left" style={{color: 'black'}}>Committee Review Completion</h1>
             <CommitteeReviewTable

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -7,6 +7,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleLeft } from "@fortawesome/free-solid-svg-icons";
 import { connect } from "react-redux";
 import Spinner from "react-spinner-material";
+import Button from "@material-ui/core/Button";
+import { CSVLink } from 'react-csv';
 
 const GET = require("../../requests/get");
 
@@ -76,6 +78,12 @@ const Wrapper = styled.div`
   table.MuiTable-root {
     border: 1px solid #cccccc;
   }
+  button {
+    max-width: 200px;
+    padding: 5px 5px;
+    text-transform: uppercase;
+    font-size: 15px;
+  }
 `;
 
 // TODO: Filter the users based on their committee, schema might change
@@ -109,7 +117,8 @@ class CommitteeReview extends Component {
       committee: [],
       appCount: -1,
       sortDescending: true,
-      committeeSize: -1
+      committeeSize: -1,
+      comments: []
     };
   }
 
@@ -121,7 +130,10 @@ class CommitteeReview extends Component {
       // TODO: Filter the users based on their committee, schema might change
       // users = users.filter(checkCommittee)
 
-      this.setState({ committeeSize: users.length });
+      this.setState({
+        committeeSize: users.length,
+        users: users
+      });
       for (let i = 0; i < users.length; i++) {
         GET.getReviewCountAPI(users[i].userId).then((count) => {
           let committee = [...this.state.committee];
@@ -130,11 +142,73 @@ class CommitteeReview extends Component {
         });
       }
     });
+    GET.getAllReviewsAPI().then(reviews => {
+      this.setState({ reviews: reviews });
+    })
+    GET.getAllApplicationsAPI().then(applications => {
+      this.setState({ applications: applications });
+    })
   }
 
   goBack() {
     this.props.history.push("/admin/allcandidates");
   }
+
+  //Calculate the average ranking
+  getComments = () => {
+    let commentsTotal = []
+    this.state.applications.sort().forEach((application, i) => {
+      let comments = []
+      this.state.reviews.forEach((review) => {
+        if (
+          review.applicationId === application._id &&
+          review.userId !== "vBUgTex5MeNd57fdB8u4wv7kXZ52" &&
+          review.userId !== "hM9QRmlybTdaQkLX25FupXqjiuF2"
+        ) {
+          //Go through questions and tally the comments
+          let temp = []
+          review.comments.forEach(comment =>{
+            temp.push(comment)
+          });
+          review.questionList.forEach(question =>{
+            question.notes.forEach(note => {
+              temp.push(note)
+            });
+          });
+          let email = ""
+          this.state.users.forEach(user => {
+            if (user.userId === review.userId){
+              email = user.email
+            }
+          });
+
+          let comment = {
+            comments: temp,
+            userId: email
+          }
+          if (comment.comments.length !== 0){
+            comments.push(comment)
+          }
+
+        }
+      })
+      let newComment = {
+        Name: application["Organization Name"] + ' (Total Commenters: ' + comments.length + ')',
+        Comments: ""
+      }
+      commentsTotal.push(newComment)
+      comments.forEach(comment => {
+        comment.comments.forEach(c => {
+          let newComment = {
+            Name: "",
+            Comments: c.value + ' (' + comment.userId + ')'
+          }
+          commentsTotal.push(newComment)
+        });
+      });
+    });
+    this.setState({ comments: commentsTotal });
+  };
 
   render() {
     return (
@@ -156,6 +230,34 @@ class CommitteeReview extends Component {
                   Back to Candidate Submissions
                 </span>
               </p>
+              <div className="button-container">
+                {/*<Button
+                  variant="contained"
+                  color="primary"
+                  target="_blank"
+                  value="OpenCommittee"
+                  style={{width: '250px', maxWidth: '250px'}}
+                  onClick={() => {
+                    this.getComments()
+                  }}
+                >
+                  Get Comments
+                </Button>*/}
+                <CSVLink data={this.state.comments}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    target="_blank"
+                    value="ExportData"
+                    style={{width: '250px', maxWidth: '250px'}}
+                    onClick={() => {
+                      this.getComments()
+                    }}
+                  >
+                    Export Comments Data
+                  </Button>
+                </CSVLink>
+              </div>
             </Header>
             <h1 align="left" style={{color: 'black'}}>Committee Review Completion</h1>
             <CommitteeReviewTable

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -50,7 +50,7 @@ const Wrapper = styled.div`
     max-width: 854px;
     width: 90vw;
     margin: 0;
-    padding-bottom: 0px;
+    padding-bottom: 10px;
     vertical-align: center;
   }
   .table {

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -154,7 +154,7 @@ class CommitteeReview extends Component {
     this.props.history.push("/admin/allcandidates");
   }
 
-  //Calculate the average ranking
+  // Get comments from users on each application
   getComments = () => {
     let commentsTotal = []
     this.state.applications.sort().forEach((application, i) => {

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -52,7 +52,7 @@ const Wrapper = styled.div`
     max-width: 854px;
     width: 90vw;
     margin: 0;
-    padding-bottom: 20px;
+    padding-bottom: 0px;
     vertical-align: center;
   }
   .table {
@@ -231,18 +231,6 @@ class CommitteeReview extends Component {
                 </span>
               </p>
               <div className="button-container">
-                {/*<Button
-                  variant="contained"
-                  color="primary"
-                  target="_blank"
-                  value="OpenCommittee"
-                  style={{width: '250px', maxWidth: '250px'}}
-                  onClick={() => {
-                    this.getComments()
-                  }}
-                >
-                  Get Comments
-                </Button>*/}
                 <CSVLink data={this.state.comments}>
                   <Button
                     variant="contained"
@@ -250,11 +238,9 @@ class CommitteeReview extends Component {
                     target="_blank"
                     value="ExportData"
                     style={{width: '250px', maxWidth: '250px'}}
-                    onClick={() => {
-                      this.getComments()
-                    }}
+                    onClick={() => { this.getComments() }}
                   >
-                    Export Comments Data
+                    Export Comments
                   </Button>
                 </CSVLink>
               </div>

--- a/src/Components/AllCandidates/CommitteeReviewTable.jsx
+++ b/src/Components/AllCandidates/CommitteeReviewTable.jsx
@@ -33,7 +33,9 @@ function CommitteeReviewTable(props) {
           pageSize: 10,
           rowStyle: rowStyle,
           search: true,
-          showTitle: false
+          showTitle: false,
+          exportButton: true,
+          exportAllData: true
         }}
       />
     </div>

--- a/src/Components/List/ApplicationList/AllApplicationsTable.jsx
+++ b/src/Components/List/ApplicationList/AllApplicationsTable.jsx
@@ -29,7 +29,7 @@ function AllApplicationsTable(props) {
           .substring(4, 16);
       }
     },
-    { title: "", field: "applicantLink", sorting: false, searchable: false }
+    { title: "", field: "applicantLink", sorting: false, searchable: false, export: false }
   ];
   return (
     <div>
@@ -44,7 +44,9 @@ function AllApplicationsTable(props) {
           pageSize: 10,
           rowStyle: rowStyle,
           search: true,
-          showTitle: false
+          showTitle: false,
+          exportButton: true,
+          exportAllData: true
         }}
       />
     </div>


### PR DESCRIPTION
Using materiai-table to export. Very simple to do.

Export button looks like:
![image](https://user-images.githubusercontent.com/13268990/88462054-9f29c900-ce76-11ea-8b86-f1634a5a1ebd.png)

Requires a second click unfortunately, despite material table only supporting csv export. This pops up after 1 click:
![image](https://user-images.githubusercontent.com/13268990/88462107-da2bfc80-ce76-11ea-886a-c23f58f6f53e.png)

Final table export:
![image](https://user-images.githubusercontent.com/13268990/88462130-047dba00-ce77-11ea-91d8-cb4dae98cd8e.png)

Note: it exports whatever state the table is in, sorted or filtered. For example, this is the result after a search of "Cambridge":
![image](https://user-images.githubusercontent.com/13268990/88462145-2119f200-ce77-11ea-8170-3b9037c5de2b.png)

