### PR TITLE
Refactor stacked rankings endpoint to return suggested rating

### DIFF
--- a/backend/routes/applications.js
+++ b/backend/routes/applications.js
@@ -6,7 +6,7 @@ const db = require("../mongo.js");
 
 router.get("/", function(req, res) {
   if (req.query.count) {
-    db.applications.countDocuments().then(count => {
+    db.applications.countDocuments().then((count) => {
       res.json(count);
     });
     return;
@@ -25,7 +25,10 @@ router.get("/:userid", function(req, res) {
   db.applications
     .aggregate([
       {
-        $project: { "Organization Name (legal name)": 1 }
+        $project: {
+          "Organization Name (legal name)": 1,
+          "Organization Name": 1
+        }
       },
       {
         $lookup: {

--- a/backend/routes/stackedRankings.js
+++ b/backend/routes/stackedRankings.js
@@ -28,7 +28,31 @@ router.get("/:userid", function(req, res) {
                 }
               }
             },
-            { $project: { rating: 1 } }
+            {
+              $addFields: {
+                questionRatings: {
+                  $map: {
+                    input: "$questionList",
+                    as: "item",
+                    in: {
+                      $cond: {
+                        if: { $gte: ["$$item.rating", 0] },
+                        then: "$$item.rating",
+                        else: null
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              $project: {
+                rating: 1,
+                suggested: {
+                  $avg: "$questionRatings"
+                }
+              }
+            }
           ],
           as: "ratingInfo"
         }
@@ -39,7 +63,12 @@ router.get("/:userid", function(req, res) {
           let: { appId: "$applications.appId" },
           pipeline: [
             { $match: { $expr: { $eq: ["$_id", "$$appId"] } } },
-            { $project: { "Organization Name": 1 } }
+            {
+              $project: {
+                "Organization Name": 1,
+                "Organization Name (legal name)": 1
+              }
+            }
           ],
           as: "applicationInfo"
         }
@@ -68,8 +97,7 @@ router.get("/:userid", function(req, res) {
     });
 });
 
-
-//Admin stats 
+//Admin stats
 router.get("/", function(req, res) {
   db.stackedRankings
     .find()
@@ -80,7 +108,6 @@ router.get("/", function(req, res) {
       res.send(err);
     });
 });
-
 
 //upsert create a new document if the query did not retrieve any documents
 //satisfying the criteria. It instead does an insert.

--- a/src/Components/StackedRankings/RankingCard.jsx
+++ b/src/Components/StackedRankings/RankingCard.jsx
@@ -73,7 +73,10 @@ function RankingCard({ companyName, rating, appId, push, suggested }) {
           ) : (
             <div className={classes.rating}>
               Suggested Rating:{" "}
-              {suggested !== 0 ? suggested.toFixed(2) : rating.toFixed(2)}/5
+              {suggested != null && suggested !== 0
+                ? suggested.toFixed(2)
+                : rating.toFixed(2)}
+              /5
             </div>
           )}
           <Button


### PR DESCRIPTION
Noticed it was a little busy on the frontend, moved most logic to the agg pipeline in stacked rankings route.
Also, is there a reason we don't just store the suggested rating with the reviews? Seems like it would make things easier.
Just to make sure I understood what was there already: it seems like we calc the suggested rating of an app based only on the user's scored questions (aka if they rated the whole app, but say only 2 individual question, the suggested rating is the avg of those 2 questions).