### PR TITLE
Sample form sections / questions for the form builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.firebase
 /.pnp
 .pnp.js
+src/*.d.ts
 
 # testing
 /coverage

--- a/src/Components/DecisionCanvas/CanvasCard.jsx
+++ b/src/Components/DecisionCanvas/CanvasCard.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import { makeStyles } from "@material-ui/core/styles";
-
 import Card from "@material-ui/core/Card";
 import Collapse from "@material-ui/core/Collapse";
 import Divider from "@material-ui/core/Divider";

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -6,9 +6,17 @@ import customFormStateReducer, {
   EDIT_DESCRIPTION
 } from "../../Reducers/CustomFormStateReducer";
 import styled from "styled-components";
+import FormCard from "./FormCard";
+import FormSection from "./FormSection";
 
 const Wrapper = styled.div`
   margin-top: ${HEADER_HEIGHT}px;
+`;
+
+const FormWrapper = styled.div`
+  margin-top: 10%;
+  padding-left: 10%;
+  padding-right: 10%;
 `;
 
 const Header = styled.div`
@@ -79,6 +87,10 @@ function CreateEditForm() {
           onChange={onDescriptionChange}
         />
       </Header>
+      <FormWrapper>
+        <FormSection />
+        <FormCard />
+      </FormWrapper>
     </Wrapper>
   );
 }

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -119,7 +119,7 @@ function CreateEditForm() {
         />
       </Header>
       {sections.map((section, key) => (
-        <FormWrapper>
+        <FormWrapper key={key + "_wrapper"}>
           <FormSection
             key={key}
             numSections={sections.length}
@@ -130,6 +130,8 @@ function CreateEditForm() {
           {section.cards.map((card, key) => (
             <FormCard
               key={key}
+              numCards={section.cards.length}
+              card={key + 1}
               type={card.type}
               question={card.question}
               options={card.options}

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -77,11 +77,26 @@ function CreateEditForm() {
     let sections = [
       {
         title: "About Your Charity",
-        desc: "Section Type: Admin Info"
+        desc: "Section Type: Admin Info",
+        cards: [
+          {
+            type: "short_answer",
+            question: "What is the name of your charity?",
+            required: ""
+          }
+        ]
       },
       {
         title: "Untitled Section",
-        desc: "Section Type: Decision Criteria"
+        desc: "Section Type: Decision Criteria",
+        cards: [
+          {
+            type: "untitled",
+            question: "Untitled Question",
+            options: ["Option 1"],
+            required: ""
+          }
+        ]
       }
     ];
 
@@ -112,7 +127,15 @@ function CreateEditForm() {
             title={section.title}
             description={section.desc}
           />
-          <FormCard key={key} />
+          {section.cards.map((card, key) => (
+            <FormCard
+              key={key}
+              type={card.type}
+              question={card.question}
+              options={card.options}
+              required={card.required}
+            />
+          ))}
         </FormWrapper>
       ))}
     </Wrapper>

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useCallback } from "react";
+import React, { useReducer, useState, useEffect, useCallback } from "react";
 import { HEADER_HEIGHT } from "../Header/Header";
 import InputBase from "@material-ui/core/InputBase";
 import customFormStateReducer, {
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
 `;
 
 const FormWrapper = styled.div`
-  margin-top: 10%;
+  margin-top: 50px;
   padding-left: 10%;
   padding-right: 10%;
 `;
@@ -57,6 +57,7 @@ const defaultForm = {
 
 function CreateEditForm() {
   const [formState, dispatch] = useReducer(customFormStateReducer, defaultForm);
+  const [sections, setSections] = useState([]);
 
   const onTitleChange = useCallback(
     (e) => {
@@ -71,6 +72,21 @@ function CreateEditForm() {
     },
     [dispatch]
   );
+
+  useEffect(() => {
+    let sections = [
+      {
+        title: "About Your Charity",
+        desc: "Section Type: Admin Info"
+      },
+      {
+        title: "Untitled Section",
+        desc: "Section Type: Decision Criteria"
+      }
+    ];
+
+    setSections(sections);
+  }, []);
 
   return (
     <Wrapper>
@@ -87,10 +103,18 @@ function CreateEditForm() {
           onChange={onDescriptionChange}
         />
       </Header>
-      <FormWrapper>
-        <FormSection />
-        <FormCard />
-      </FormWrapper>
+      {sections.map((section, key) => (
+        <FormWrapper>
+          <FormSection
+            key={key}
+            numSections={sections.length}
+            section={key + 1}
+            title={section.title}
+            description={section.desc}
+          />
+          <FormCard key={key} />
+        </FormWrapper>
+      ))}
     </Wrapper>
   );
 }

--- a/src/Components/FormCreation/FormCard.js
+++ b/src/Components/FormCreation/FormCard.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
   }
 });
 
-function FormCard({ key, type, question, options, required }) {
+function FormCard({ numCards, card, type, question, options, required }) {
   const classes = useStyles();
 
   return (
@@ -34,7 +34,7 @@ function FormCard({ key, type, question, options, required }) {
       <CardHeader
         classes={{ title: classes.title }}
         title={question}
-        id={key}
+        id={card}
       />
       <CardContent classes={{ root: classes.content }}>todo</CardContent>
     </Card>

--- a/src/Components/FormCreation/FormCard.js
+++ b/src/Components/FormCreation/FormCard.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+
+const useStyles = makeStyles({
+  collapse: {
+    marginBottom: 16
+  },
+  content: { marginTop: -16 },
+  expandOpen: {
+    transform: "rotate(180deg)"
+  },
+  root: (index) => ({
+    fontSize: 14,
+    borderRadius: 0,
+    borderLeft: `4px solid #2261AD`,
+    boxShadow: "0 2px 3px 1px #cccccc",
+    marginBottom: 20
+  }),
+  title: {
+    color: "#000",
+    fontSize: "20px",
+    fontWeight: "500"
+  }
+});
+
+function FormCard({
+  children,
+  expanded,
+  id,
+  onHeaderClick,
+  onLinkClick,
+  review,
+  title,
+  update
+}) {
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.root}>
+      <CardHeader
+        classes={{ title: classes.title }}
+        title={"Card 1"}
+        id={"sect_1"}
+      />
+      <CardContent classes={{ root: classes.content }}>todo</CardContent>
+    </Card>
+  );
+}
+
+export default FormCard;

--- a/src/Components/FormCreation/FormCard.js
+++ b/src/Components/FormCreation/FormCard.js
@@ -26,24 +26,15 @@ const useStyles = makeStyles({
   }
 });
 
-function FormCard({
-  children,
-  expanded,
-  id,
-  onHeaderClick,
-  onLinkClick,
-  review,
-  title,
-  update
-}) {
+function FormCard({ key, type, question, options, required }) {
   const classes = useStyles();
 
   return (
     <Card className={classes.root}>
       <CardHeader
         classes={{ title: classes.title }}
-        title={"Card 1"}
-        id={"sect_1"}
+        title={question}
+        id={key}
       />
       <CardContent classes={{ root: classes.content }}>todo</CardContent>
     </Card>

--- a/src/Components/FormCreation/FormSection.js
+++ b/src/Components/FormCreation/FormSection.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+
+const useStyles = makeStyles({
+  collapse: {
+    marginBottom: 16
+  },
+  content: { marginTop: -16 },
+  expandOpen: {
+    transform: "rotate(180deg)"
+  },
+  root: (index) => ({
+    fontSize: 14,
+    borderRadius: 0,
+    borderTop: `8px solid #2261AD`,
+    boxShadow: "0 2px 3px 1px #cccccc",
+    marginBottom: 20
+  }),
+  title: {
+    color: "#000",
+    fontSize: "20px",
+    fontWeight: "500"
+  }
+});
+
+function FormSection({
+  children,
+  expanded,
+  id,
+  onHeaderClick,
+  onLinkClick,
+  review,
+  title,
+  update
+}) {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <p
+        style={{
+          borderTopLeftRadius: "4px",
+          borderTopRightRadius: "4px",
+          marginBottom: "0px",
+          fontSize: "14px",
+          backgroundColor: "#2261AD",
+          color: "white",
+          width: "fit-content",
+          paddingLeft: "10px",
+          paddingRight: "10px",
+          paddingTop: "5px",
+          paddingBottom: "5px"
+        }}
+      >
+        Section 1 of 2
+      </p>
+      <Card className={classes.root}>
+        <CardHeader
+          classes={{ title: classes.title }}
+          title={"About Your Charity"}
+          id={"sect_1"}
+        />
+        <CardContent classes={{ root: classes.content }}>todo</CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default FormSection;

--- a/src/Components/FormCreation/FormSection.js
+++ b/src/Components/FormCreation/FormSection.js
@@ -39,28 +39,23 @@ const useStyles = makeStyles({
   }
 });
 
-function FormSection({
-  children,
-  expanded,
-  id,
-  onHeaderClick,
-  onLinkClick,
-  review,
-  title,
-  update
-}) {
+function FormSection({ numSections, section, title, description }) {
   const classes = useStyles();
 
   return (
     <div>
-      <span className={classes.section_title}>Section 1 of 2</span>
+      <span className={classes.section_title}>
+        Section {section} of {numSections}
+      </span>
       <Card className={classes.root}>
         <CardHeader
           classes={{ title: classes.title }}
-          title={"About Your Charity"}
-          id={"sect_1"}
+          title={title}
+          id={section}
         />
-        <CardContent classes={{ root: classes.content }}>todo</CardContent>
+        <CardContent classes={{ root: classes.content }}>
+          {description}
+        </CardContent>
       </Card>
     </div>
   );

--- a/src/Components/FormCreation/FormSection.js
+++ b/src/Components/FormCreation/FormSection.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
   }
 });
 
-function FormSection({ numSections, section, title, description }) {
+function FormSection({ key, numSections, section, title, description }) {
   const classes = useStyles();
 
   return (
@@ -48,11 +48,7 @@ function FormSection({ numSections, section, title, description }) {
         Section {section} of {numSections}
       </span>
       <Card className={classes.root}>
-        <CardHeader
-          classes={{ title: classes.title }}
-          title={title}
-          id={section}
-        />
+        <CardHeader classes={{ title: classes.title }} title={title} id={key} />
         <CardContent classes={{ root: classes.content }}>
           {description}
         </CardContent>

--- a/src/Components/FormCreation/FormSection.js
+++ b/src/Components/FormCreation/FormSection.js
@@ -23,6 +23,19 @@ const useStyles = makeStyles({
     color: "#000",
     fontSize: "20px",
     fontWeight: "500"
+  },
+  section_title: {
+    borderTopLeftRadius: "4px",
+    borderTopRightRadius: "4px",
+    marginBottom: "0px",
+    fontSize: "14px",
+    backgroundColor: "#2261AD",
+    color: "white",
+    width: "fit-content",
+    paddingLeft: "10px",
+    paddingRight: "10px",
+    paddingTop: "5px",
+    paddingBottom: "5px"
   }
 });
 
@@ -40,23 +53,7 @@ function FormSection({
 
   return (
     <div>
-      <p
-        style={{
-          borderTopLeftRadius: "4px",
-          borderTopRightRadius: "4px",
-          marginBottom: "0px",
-          fontSize: "14px",
-          backgroundColor: "#2261AD",
-          color: "white",
-          width: "fit-content",
-          paddingLeft: "10px",
-          paddingRight: "10px",
-          paddingTop: "5px",
-          paddingBottom: "5px"
-        }}
-      >
-        Section 1 of 2
-      </p>
+      <span className={classes.section_title}>Section 1 of 2</span>
       <Card className={classes.root}>
         <CardHeader
           classes={{ title: classes.title }}

--- a/src/Components/FormCreation/FormSection.js
+++ b/src/Components/FormCreation/FormSection.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
   }
 });
 
-function FormSection({ key, numSections, section, title, description }) {
+function FormSection({ numSections, section, title, description }) {
   const classes = useStyles();
 
   return (
@@ -48,7 +48,11 @@ function FormSection({ key, numSections, section, title, description }) {
         Section {section} of {numSections}
       </span>
       <Card className={classes.root}>
-        <CardHeader classes={{ title: classes.title }} title={title} id={key} />
+        <CardHeader
+          classes={{ title: classes.title }}
+          title={title}
+          id={section}
+        />
         <CardContent classes={{ root: classes.content }}>
           {description}
         </CardContent>

--- a/src/appRoutes.js
+++ b/src/appRoutes.js
@@ -10,7 +10,7 @@ import CreateEditForm from "./Components/FormCreation/CreateEditForm";
 path: "/",          =>Add the path to the switch in app.js (makes it a valid route)
 component: Home,    =>The component to be loaded at the path specified
 title: "Home",      =>The title of the path, more for documentation
-groups: []          =>A list of groups Ex. ["admink", "user"].
+groups: []          =>A list of groups Ex. ["admin", "user"].
                       =>If [] then the user only has to be authenticated
                       =>If non-empty then the user must be apart of at LEAST ONE group and authenticated
 */


### PR DESCRIPTION
Creating sample form sections / questions when the form builder is first opened.

Looks like this:
![image](https://user-images.githubusercontent.com/13268990/90460813-b4d78a80-e0d2-11ea-9b7e-e55f8ac0b993.png)

Some things that I won't do in this PR, since it is done in separate tasks:
- using data that can be modified (add/remove sections or cards)
- the card types (multiple choice, short answer, etc)

Everything else should be handled here in a manner that should be easy to modify later.