### PR TITLE
Updated gitignore to filter auto generated file from typescript usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.firebase
 /.pnp
 .pnp.js
+src/*.d.ts
 
 # testing
 /coverage


### PR DESCRIPTION
Doing this in a separate PR because the one I am currently working on may take a couple weeks to complete.

Addresses the auto generated file `react-app-env.d.ts` in the `src/` folder. It is generated by create react app because of our typescript usage.