### PR TITLE
Multiple choice question editor frontend

### DIFF
--- a/src/Components/FormCreation/CreateEditMultipleChoice.js
+++ b/src/Components/FormCreation/CreateEditMultipleChoice.js
@@ -1,0 +1,193 @@
+import React, { useState } from "react";
+import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
+import Close from "@material-ui/icons/Close";
+import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
+import IconButton from "@material-ui/core/IconButton";
+import InputBase from "@material-ui/core/InputBase";
+import Radio from "@material-ui/core/Radio";
+import { withStyles, makeStyles } from "@material-ui/core/styles";
+import styled from "styled-components";
+
+import { reorder } from "../../Utils/dragAndDropUtils";
+
+const useStyles = makeStyles({
+  closeRoot: {
+    display: "inline-block",
+    position: "absolute",
+    left: "776px",
+    bottom: "2px"
+  },
+  droppableSection: {
+    display: "flex"
+  },
+  dragIndicator: {
+    display: "inline-block",
+    position: "absolute",
+    bottom: "5px"
+  },
+  dragIndicatorVisible: {
+    color: "#DADADA"
+  },
+  dragIndicatorHidden: {
+    color: "#FFFFFF"
+  },
+  inputFocused: {
+    borderBottom: "1px solid #2261AD"
+  }
+});
+
+const Wrapper = styled.div`
+  margin-top: 16px;
+  margin-bottom: 33px;
+  width: 816px;
+`;
+
+const OptionWrapper = styled.div`
+  position: relative;
+`;
+
+const OptionNameInput = styled(InputBase)`
+  && {
+    width: 716px;
+    display: inline-block;
+    line-height: 21px;
+    overflow-y: auto;
+    max-height: 48px;
+    position: absolute;
+    bottom: 0px;
+    left: 56px;
+  }
+  textarea {
+    font-size: 14px;
+    color: #888888;
+  }
+`;
+
+const GreyRadio = withStyles({
+  root: {
+    color: "rgba(0, 0, 0, 0.38)",
+    paddingLeft: "24px",
+    paddingBottom: "5px"
+  }
+})((props) => <Radio color="default" disabled checked={false} {...props} />);
+
+function CreateEditMultipleChoice() {
+  const styles = useStyles();
+
+  const [options, setOptions] = useState(["Option 1"]);
+  const [hoveredOption, setHoveredOption] = useState(-1);
+
+  const onAddOption = (event) => {
+    setOptions(options.concat(""));
+    event.target.blur();
+  };
+
+  const onEditOption = (index, value) => {
+    const newOptions = [
+      ...options.slice(0, index),
+      [value],
+      ...options.slice(index + 1)
+    ];
+    setOptions(newOptions);
+  };
+
+  const onDeleteOption = (index) => {
+    const newOptions = [
+      ...options.slice(0, index),
+      ...options.slice(index + 1)
+    ];
+    setOptions(newOptions);
+  };
+
+  const onDragEnd = (result) => {
+    // dropped outside the list
+    if (!result.destination) {
+      return;
+    }
+
+    const reorderedOptions = reorder(
+      options,
+      result.source.index,
+      result.destination.index
+    );
+
+    setOptions(reorderedOptions);
+  };
+
+  const onBeforeDragStart = () => {
+    document.activeElement.blur();
+  };
+
+  return (
+    <Wrapper>
+      <DragDropContext
+        onDragEnd={onDragEnd}
+        onBeforeDragStart={onBeforeDragStart}
+      >
+        <Droppable droppableId="droppable">
+          {(provided) => (
+            <div {...provided.droppableProps} ref={provided.innerRef}>
+              {options.map((data, index) => (
+                <Draggable draggableId={`${index}`} index={index} key={index}>
+                  {(provided, snapshot) => (
+                    <div
+                      onMouseEnter={() => setHoveredOption(index)}
+                      onMouseLeave={() => setHoveredOption(-1)}
+                      className={styles.droppableSection}
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
+                    >
+                      <OptionWrapper key={index}>
+                        <DragIndicatorIcon
+                          className={`${styles.dragIndicator} 
+                            ${
+                              hoveredOption === index || snapshot.isDragging
+                                ? styles.dragIndicatorVisible
+                                : styles.dragIndicatorHidden
+                            }`}
+                        />
+                        <GreyRadio />
+                        <OptionNameInput
+                          classes={{ focused: styles.inputFocused }}
+                          autoFocus={true}
+                          placeholder="Option..."
+                          value={data}
+                          onChange={(event) =>
+                            onEditOption(index, event.target.value)
+                          }
+                        />
+                        <IconButton
+                          onClick={() => onDeleteOption(index)}
+                          classes={{ root: styles.closeRoot }}
+                          size="small"
+                        >
+                          <Close />
+                        </IconButton>
+                      </OptionWrapper>
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+
+      <OptionWrapper>
+        <DragIndicatorIcon
+          className={`${styles.dragIndicator} ${styles.dragIndicatorHidden}`}
+        />
+        <GreyRadio />
+        <OptionNameInput
+          placeholder="Add option"
+          onFocus={onAddOption}
+          value={""}
+        />
+      </OptionWrapper>
+    </Wrapper>
+  );
+}
+
+export default CreateEditMultipleChoice;

--- a/src/Components/FormCreation/CreateEditMultipleChoice.js
+++ b/src/Components/FormCreation/CreateEditMultipleChoice.js
@@ -32,7 +32,11 @@ const useStyles = makeStyles({
     color: "#FFFFFF"
   },
   inputFocused: {
-    borderBottom: "1px solid #2261AD"
+    // focused styling has priority over hovered styling
+    boxShadow: "0 1px 0 #2261AD !important"
+  },
+  inputHovered: {
+    boxShadow: "0 1px 0 #DADADA"
   }
 });
 
@@ -149,6 +153,11 @@ function CreateEditMultipleChoice() {
                         />
                         <GreyRadio />
                         <OptionNameInput
+                          className={
+                            hoveredOption === index || snapshot.isDragging
+                              ? styles.inputHovered
+                              : ""
+                          }
                           classes={{ focused: styles.inputFocused }}
                           autoFocus={true}
                           placeholder="Option..."

--- a/src/Components/FormCreation/CreateEditMultipleChoice.js
+++ b/src/Components/FormCreation/CreateEditMultipleChoice.js
@@ -75,10 +75,11 @@ const GreyRadio = withStyles({
   }
 })((props) => <Radio color="default" disabled checked={false} {...props} />);
 
-function CreateEditMultipleChoice() {
+function CreateEditMultipleChoice({ data }) {
   const styles = useStyles();
 
-  const [options, setOptions] = useState(["Option 1"]);
+  // options is a string array
+  const [options, setOptions] = useState(data);
   const [hoveredOption, setHoveredOption] = useState(-1);
 
   const onAddOption = (event) => {

--- a/src/Components/StackedRankings/StackedRankings.jsx
+++ b/src/Components/StackedRankings/StackedRankings.jsx
@@ -8,6 +8,7 @@ import RankingCard from "./RankingCard";
 import usePromise from "../../Hooks/usePromise";
 import { getAllStackingsAPI } from "../../requests/get";
 import * as UPDATE from "../../requests/update";
+import { reorder } from "../../Utils/dragAndDropUtils";
 
 const CARD_HEIGHT = 56;
 const CARD_SPACING = 12;
@@ -92,15 +93,6 @@ const NumbersColumn = styled.div`
   position: absolute;
   right: 100%;
 `;
-
-// a little function to help us with reordering the result
-function reorder(list, startIndex, endIndex) {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
-
-  return result;
-}
 
 function compare(a, b) {
   if (a.rating < b.rating) {

--- a/src/Utils/dragAndDropUtils.js
+++ b/src/Utils/dragAndDropUtils.js
@@ -1,0 +1,7 @@
+export const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
+};


### PR DESCRIPTION
This PR only introduces the frontend component for the multiple choice editor (excludes collapsed view). It does not include general editor components in the top and bottom bar (e.g. title, description, required, etc.), which should be a wrapper over all types of questions.

This PR also includes a minor change to StackedRankings, which now uses the shared `reorder` util function in `dragAndDropUtils.js`.

**Newly created:**
<img width="800" alt="new-mc-question" src="https://user-images.githubusercontent.com/30205929/90821016-424bf200-e300-11ea-9196-0eb5d8be906a.PNG">

**Adding and deleting:**
![mc-add-delete](https://user-images.githubusercontent.com/30205929/92028961-da9b9b00-ed32-11ea-9e05-63b196d02181.gif)



**Hover and active states:**
![mc-hover-and-active](https://user-images.githubusercontent.com/30205929/92028974-dd968b80-ed32-11ea-8e5e-1bb893e4bb85.gif)



**Drag and drop:**
![mc-drag-and-drop](https://user-images.githubusercontent.com/30205929/92028985-dff8e580-ed32-11ea-865e-fa99f40f6a51.gif)

