### PR TITLE
Fix ranking card height issue

### DIFF
--- a/src/Components/StackedRankings/RankingCard.jsx
+++ b/src/Components/StackedRankings/RankingCard.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     marginRight: 26
   },
   root: {
-    height: 56,
+    minHeight: 56,
     borderRadius: 0,
     boxShadow: "0px 2px 3px 1px #cccccc"
   },


### PR DESCRIPTION
Fixing this issue (seen on smaller screens):

![image](https://user-images.githubusercontent.com/30205929/90825481-fa7c9900-e306-11ea-85f6-289f32360bf2.png)

