### PR TITLE
Fix margin issues caused by new navbar

### DIFF
--- a/src/Components/Admin/UserManagement.jsx
+++ b/src/Components/Admin/UserManagement.jsx
@@ -9,7 +9,7 @@ import NewUserDialog from "./NewUserDialog";
 import UserManagementTable from "./UserManagementTable";
 
 const Wrapper = styled.div`
-  margin-top: 148px;
+  margin-top: 50px;
   text-align: left;
   padding: 0 64px;
 `;

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -40,7 +40,7 @@ const Header = styled.div`
 
 const Wrapper = styled.div`
   margin-top: 50px;
-  padding: 0 50px;
+  padding: 0 136px;
   h1 {
     font-family: Roboto;
     font-style: normal;

--- a/src/Components/AllCandidates/AllCandidates.jsx
+++ b/src/Components/AllCandidates/AllCandidates.jsx
@@ -39,8 +39,8 @@ const Header = styled.div`
 `;
 
 const Wrapper = styled.div`
-  margin-top: 150px;
-  padding: 0 136px;
+  margin-top: 50px;
+  padding: 0 50px;
   h1 {
     font-family: Roboto;
     font-style: normal;

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -32,7 +32,7 @@ const Header = styled.div`
 
 const Wrapper = styled.div`
   margin-top: 50px;
-  padding: 0 50px;
+  padding: 0 136px;
   h1 {
     font-family: Roboto;
     font-style: normal;

--- a/src/Components/AllCandidates/CommitteeReview.jsx
+++ b/src/Components/AllCandidates/CommitteeReview.jsx
@@ -31,8 +31,8 @@ const Header = styled.div`
 `;
 
 const Wrapper = styled.div`
-  margin-top: 150px;
-  padding: 0 136px;
+  margin-top: 50px;
+  padding: 0 50px;
   h1 {
     font-family: Roboto;
     font-style: normal;

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -9,10 +9,6 @@ import CreateEditFormHeader from "./CreateEditFormHeader";
 import { defaultFormState } from "./CreateEditFormStateManagement";
 import customFormSectionsReducer from "../../Reducers/CustomFormSectionsReducer";
 
-const Wrapper = styled.div`
-  margin-top: ${HEADER_HEIGHT}px;
-`;
-
 const FormWrapper = styled.div`
   margin-top: 50px;
   padding-left: 15%;
@@ -75,7 +71,7 @@ function CreateEditForm() {
   }
 
   return (
-    <Wrapper>
+    <div>
       <CreateEditFormHeader {...headerData} onChange={setHeaderData} />
       {sections &&
         sections.map((section, key) => (
@@ -91,7 +87,7 @@ function CreateEditForm() {
             />
           </FormWrapper>
         ))}
-    </Wrapper>
+    </div>
   );
 }
 

--- a/src/Components/FormCreation/CreateEditForm.js
+++ b/src/Components/FormCreation/CreateEditForm.js
@@ -1,5 +1,4 @@
 import React, { useReducer, useEffect, useState, useContext } from "react";
-import { HEADER_HEIGHT } from "../Header/Header";
 import styled from "styled-components";
 import FormSection from "./FormSection";
 import { AuthContext } from "../../Authentication/Auth.js";

--- a/src/Components/List/ApplicationList/AllApplications.jsx
+++ b/src/Components/List/ApplicationList/AllApplications.jsx
@@ -14,8 +14,8 @@ import {
 } from "../../../requests/get";
 
 const Wrapper = styled.div`
-  margin-top: 150px;
-  padding: 0 136px;
+  margin-top: 50px;
+  padding: 0 50px;
   text-align: left;
   padding-bottom: 30px;
   h1 {

--- a/src/Components/List/ApplicationList/AllApplications.jsx
+++ b/src/Components/List/ApplicationList/AllApplications.jsx
@@ -14,7 +14,7 @@ import {
 } from "../../../requests/get";
 
 const Wrapper = styled.div`
-  margin-top: 50px;
+  margin-top: 100px;
   padding: 0 136px;
   text-align: left;
   padding-bottom: 30px;

--- a/src/Components/List/ApplicationList/AllApplications.jsx
+++ b/src/Components/List/ApplicationList/AllApplications.jsx
@@ -15,7 +15,7 @@ import {
 
 const Wrapper = styled.div`
   margin-top: 50px;
-  padding: 0 50px;
+  padding: 0 136px;
   text-align: left;
   padding-bottom: 30px;
   h1 {

--- a/src/Components/StackedRankings/StackedRankings.jsx
+++ b/src/Components/StackedRankings/StackedRankings.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
     position: "relative"
   },
   root: {
-    marginTop: 136,
+    marginTop: 50,
     padding: "0 168px",
     textAlign: "left",
     "& h1": {

--- a/src/Components/StackedRankings/StackedRankings.jsx
+++ b/src/Components/StackedRankings/StackedRankings.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
     position: "relative"
   },
   root: {
-    marginTop: 50,
+    marginTop: 100,
     padding: "0 168px",
     textAlign: "left",
     "& h1": {


### PR DESCRIPTION
Due to the new navbar, there is a lot of unnecessary margin-top padding occurring. I am reducing the padding (and removing completely for the forms) so that it looks better. So below the before/after on a few pages.

Forms before:
![image](https://user-images.githubusercontent.com/13268990/97789867-57fc5400-1b9a-11eb-8039-843bbc3caf6b.png)

Forms after:
![image](https://user-images.githubusercontent.com/13268990/97789840-300cf080-1b9a-11eb-8c50-206b3ec34352.png)

Stacked rankings before:
![image](https://user-images.githubusercontent.com/13268990/97789856-4ca92880-1b9a-11eb-8de3-85f9d56ae6e4.png)

Stacked rankings after:
![image](https://user-images.githubusercontent.com/13268990/97789848-41ee9380-1b9a-11eb-9d26-0a055b93ba71.png)

Other pages changed:
- User management
- All candidates
- Committee review
- All applications