### PR TITLE
Add visual studio generated folders to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ src/*.d.ts
 .env.test.local
 .env.production.local
 .env
-/.vs
-backend/.vs
+*/.vs
 
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ src/*.d.ts
 .env.test.local
 .env.production.local
 .env
+/.vs
+backend/.vs
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
I noticed when I was helping @nehageorge with a few errors in her branch that there were .vs and backend/.vs folders appearing that are generated from visual studio. I thought I would include those in our .gitignore.

@nehageorge can you verify this resolves your issue? ie. when you are on this branch, you should not see those folders when you do git status.